### PR TITLE
Fix XML syntax for hyperv VM network interface definitions.

### DIFF
--- a/src/hyperv/hyperv_api_v1.c
+++ b/src/hyperv/hyperv_api_v1.c
@@ -1472,7 +1472,7 @@ hyperv1DomainDefParseSyntheticEthernetAdapter(virDomainDefPtr def,
     }
 
     /* get bridge name */
-    if (VIR_STRDUP(temp, vSwitch->data->Name) < 0) {
+    if (VIR_STRDUP(temp, vSwitch->data->ElementName) < 0) {
         virReportError(VIR_ERR_INTERNAL_ERROR, "%s",
                 _("Could not set bridge name"));
         goto cleanup;

--- a/src/hyperv/hyperv_api_v1.c
+++ b/src/hyperv/hyperv_api_v1.c
@@ -4247,6 +4247,7 @@ hyperv1DomainAttachDeviceFlags(virDomainPtr domain, const char *xml,
         case VIR_DOMAIN_DEVICE_CHR:
             if (hyperv1DomainAttachSerial(domain, dev->data.chr) < 0)
                 goto cleanup;
+            break;
         default:
             /* unsupported device type */
             virReportError(VIR_ERR_INTERNAL_ERROR,

--- a/src/hyperv/hyperv_api_v2.c
+++ b/src/hyperv/hyperv_api_v2.c
@@ -4374,6 +4374,7 @@ hyperv2DomainAttachDeviceFlags(virDomainPtr domain, const char *xml,
         case VIR_DOMAIN_DEVICE_CHR:
             if (hyperv2DomainAttachSerial(domain, dev->data.chr) < 0)
                 goto cleanup;
+            break;
         default:
             /* unsupported device type */
             virReportError(VIR_ERR_INTERNAL_ERROR,

--- a/src/hyperv/hyperv_api_v2.c
+++ b/src/hyperv/hyperv_api_v2.c
@@ -42,22 +42,6 @@
 
 VIR_LOG_INIT("hyperv.hyperv_api_v2")
 
-static void
-hypervDebugResponseXml(WsXmlDocH response)
-{
-#ifdef ENABLE_DEBUG
-    char *buf = NULL;
-    int len;
-
-    ws_xml_dump_memory_enc(response, &buf, &len, "UTF-8");
-
-    if (buf && len > 0)
-        VIR_DEBUG("%s", buf);
-
-    ws_xml_free_memory(buf);
-#endif
-}
-
 /*
  * WMI invocation functions
  *

--- a/src/hyperv/hyperv_api_v2.c
+++ b/src/hyperv/hyperv_api_v2.c
@@ -1509,7 +1509,7 @@ hyperv2DomainDefParseEthernetAdapter(virDomainDefPtr def,
     }
 
     /* get bridge name */
-    if (VIR_STRDUP(temp, vSwitch->data->Name) < 0) {
+    if (VIR_STRDUP(temp, vSwitch->data->ElementName) < 0) {
         virReportError(VIR_ERR_INTERNAL_ERROR, "%s",
                 _("Could not set bridge name"));
         goto cleanup;

--- a/src/hyperv/hyperv_api_v2.c
+++ b/src/hyperv/hyperv_api_v2.c
@@ -1702,7 +1702,7 @@ hyperv2DomainAttachSyntheticEthernetAdapter(virDomainPtr domain,
      */
     virBufferFreeAndReset(&query);
     virBufferAddLit(&query, MSVM_VIRTUALETHERNETSWITCH_V2_WQL_SELECT);
-    virBufferAsprintf(&query, " where Name=\"%s\"", net->data.network.name);
+    virBufferAsprintf(&query, " where ElementName=\"%s\"", net->data.bridge.brname);
 
     if (hyperv2GetMsvmVirtualEthernetSwitchList(priv, &query, &vSwitch) < 0
             || vSwitch == NULL)
@@ -1723,7 +1723,7 @@ hyperv2DomainAttachSyntheticEthernetAdapter(virDomainPtr domain,
     if (virAsprintf(&switch__PATH, "\\\\%s\\root\\virtualization\\v2:"
                 "Msvm_VirtualEthernetSwitch.CreationClassName="
                 "\"Msvm_VirtualEthernetSwitch\",Name=\"%s\"",
-                computer->data->ElementName, net->data.network.name) < 0)
+                computer->data->ElementName, vSwitch->data->Name) < 0)
         goto cleanup;
 
     /* Get the sepsd instance ID out of the XML response */

--- a/src/hyperv/hyperv_wmi.c
+++ b/src/hyperv/hyperv_wmi.c
@@ -31,10 +31,13 @@
 #include "viralloc.h"
 #include "viruuid.h"
 #include "virbuffer.h"
+#include "virlog.h"
 #include "hyperv_private.h"
 #include "hyperv_wmi.h"
 #include "virstring.h"
 #include "hyperv_wmi_cimtypes.generated.h"
+
+VIR_LOG_INIT("hyperv.hyperv_wmi")
 
 #define WS_SERIALIZER_FREE_MEM_WORKS 0
 
@@ -42,6 +45,21 @@
 #define VIR_FROM_THIS VIR_FROM_HYPERV
 
 
+void
+hypervDebugResponseXml(WsXmlDocH response)
+{
+#ifdef ENABLE_DEBUG
+    char *buf = NULL;
+    int len;
+
+    ws_xml_dump_memory_enc(response, &buf, &len, "UTF-8");
+
+    if (buf && len > 0)
+        VIR_DEBUG("%s", buf);
+
+    ws_xml_free_memory(buf);
+#endif
+}
 
 int
 hyperyVerifyResponse(WsManClient *client, WsXmlDocH response,

--- a/src/hyperv/hyperv_wmi.h
+++ b/src/hyperv/hyperv_wmi.h
@@ -43,6 +43,8 @@
 
 typedef struct _hypervObject hypervObject;
 
+void hypervDebugResponseXml(WsXmlDocH response);
+
 int hyperyVerifyResponse(WsManClient *client, WsXmlDocH response,
                          const char *detail);
 


### PR DESCRIPTION
This series fixes issues I've ran into when attaching VMs to
"vSwitches":

* define was using ````<interface type="network">```` while dumpxml was printing
````<interface type="bridge">````
* now it uses ````<interface type="bridge">```` for defines as well (same as esx driver)
and the ````<souce bridge="[name]">```` is now the vSwith name, not its GUID. This makes it work nice in tandem with net-list output that gives the user readable names:
````xml
<interface type="bridge">
  <source bridge="Red Hat VirtIO Ethernet Adapter - Virtual Switch" />
</interface>
````

the same will be output with dumpxml

* matched dumpxml behaviour do print names instead of GUIDs