### PR TITLE
hyperv: improve networking code

### DIFF
--- a/src/hyperv/hyperv_api_v1.c
+++ b/src/hyperv/hyperv_api_v1.c
@@ -4247,6 +4247,7 @@ hyperv1DomainAttachDeviceFlags(virDomainPtr domain, const char *xml,
         case VIR_DOMAIN_DEVICE_CHR:
             if (hyperv1DomainAttachSerial(domain, dev->data.chr) < 0)
                 goto cleanup;
+            break;
         default:
             /* unsupported device type */
             virReportError(VIR_ERR_INTERNAL_ERROR,

--- a/src/hyperv/hyperv_api_v2.c
+++ b/src/hyperv/hyperv_api_v2.c
@@ -4374,6 +4374,7 @@ hyperv2DomainAttachDeviceFlags(virDomainPtr domain, const char *xml,
         case VIR_DOMAIN_DEVICE_CHR:
             if (hyperv2DomainAttachSerial(domain, dev->data.chr) < 0)
                 goto cleanup;
+            break;
         default:
             /* unsupported device type */
             virReportError(VIR_ERR_INTERNAL_ERROR,

--- a/src/hyperv/hyperv_api_v2.c
+++ b/src/hyperv/hyperv_api_v2.c
@@ -42,22 +42,6 @@
 
 VIR_LOG_INIT("hyperv.hyperv_api_v2")
 
-static void
-hypervDebugResponseXml(WsXmlDocH response)
-{
-#ifdef ENABLE_DEBUG
-    char *buf = NULL;
-    int len;
-
-    ws_xml_dump_memory_enc(response, &buf, &len, "UTF-8");
-
-    if (buf && len > 0)
-        VIR_DEBUG("%s", buf);
-
-    ws_xml_free_memory(buf);
-#endif
-}
-
 /*
  * WMI invocation functions
  *

--- a/src/hyperv/hyperv_driver.c
+++ b/src/hyperv/hyperv_driver.c
@@ -112,6 +112,7 @@ hypervSetupV1(virHypervisorDriverPtr d, virNetworkDriverPtr n,
     d->domainSendKey = hyperv1DomainSendKey; /* TODO: get current version */
 
     /* Set up network driver functions */
+    n->connectListAllNetworks = hyperv1ConnectListAllNetworks; /* TODO: get current version */
     n->connectListNetworks = hyperv1ConnectListNetworks; /* TODO: get current version */
     n->connectNumOfNetworks = hyperv1ConnectNumOfNetworks; /* TODO: get current version */
     n->connectListDefinedNetworks = hyperv1ConnectListDefinedNetworks; /* TODO: get current version */
@@ -191,6 +192,7 @@ hypervSetupV2(virHypervisorDriverPtr d, virNetworkDriverPtr n,
     d->domainSendKey = hyperv2DomainSendKey; /* TODO: get current version */
 
     /* Set up network driver functions */
+    n->connectListAllNetworks = hyperv2ConnectListAllNetworks; /* TODO: get current version */
     n->connectListNetworks = hyperv2ConnectListNetworks; /* TODO: get current version */
     n->connectNumOfNetworks = hyperv2ConnectNumOfNetworks; /* TODO: get current version */
     n->connectListDefinedNetworks = hyperv2ConnectListDefinedNetworks; /* TODO: get current version */

--- a/src/hyperv/hyperv_driver.c
+++ b/src/hyperv/hyperv_driver.c
@@ -118,6 +118,10 @@ hypervSetupV1(virHypervisorDriverPtr d, virNetworkDriverPtr n,
     n->connectListDefinedNetworks = hyperv1ConnectListDefinedNetworks; /* TODO: get current version */
     n->networkLookupByName = hyperv1NetworkLookupByName; /* TODO: get current version */
     n->connectNumOfDefinedNetworks = hyperv1ConnectNumOfDefinedNetworks; /* TODO: get current version */
+    n->networkGetXMLDesc = hyperv1NetworkGetXMLDesc; /* TODO: get current version */
+    n->networkSetAutostart = hyperv1NetworkSetAutostart; /* TODO: get current version */
+    n->networkGetAutostart = hyperv1NetworkGetAutostart; /* TODO: get current version */
+    n->networkIsPersistent = hyperv1NetworkIsPersistent; /* TODO: get current version */
 
     /* set up capabilities */
     priv->caps = hyperv1CapsInit(priv);
@@ -198,7 +202,10 @@ hypervSetupV2(virHypervisorDriverPtr d, virNetworkDriverPtr n,
     n->connectListDefinedNetworks = hyperv2ConnectListDefinedNetworks; /* TODO: get current version */
     n->networkLookupByName = hyperv2NetworkLookupByName; /* TODO: get current version */
     n->connectNumOfDefinedNetworks = hyperv2ConnectNumOfDefinedNetworks; /* TODO: get current version */
-
+    n->networkGetXMLDesc = hyperv2NetworkGetXMLDesc; /* TODO: get current version */
+    n->networkSetAutostart = hyperv2NetworkSetAutostart; /* TODO: get current version */
+    n->networkGetAutostart = hyperv2NetworkGetAutostart; /* TODO: get current version */
+    n->networkIsPersistent = hyperv2NetworkIsPersistent; /* TODO: get current version */
     /* set up capabilities */
     priv->caps = hyperv2CapsInit(priv);
     if (priv->caps == NULL)

--- a/src/hyperv/hyperv_network_api_v1.h
+++ b/src/hyperv/hyperv_network_api_v1.h
@@ -32,6 +32,11 @@ int hyperv1ConnectListDefinedNetworks(virConnectPtr conn, char **const names,
         int maxnames);
 virNetworkPtr hyperv1NetworkLookupByName(virConnectPtr conn, const char *name);
 int hyperv1ConnectNumOfDefinedNetworks(virConnectPtr conn);
+char *hyperv1NetworkGetXMLDesc(virNetworkPtr network, unsigned int flags);
+int hyperv1NetworkSetAutostart(virNetworkPtr network, int autostart);
+int hyperv1NetworkGetAutostart(virNetworkPtr network, int *autostart);
+int hyperv1NetworkIsActive(virNetworkPtr network);
+int hyperv1NetworkIsPersistent(virNetworkPtr network);
 
 
 #endif /* __HYPERV_NETWORK_API_V1_H__ */

--- a/src/hyperv/hyperv_network_api_v1.h
+++ b/src/hyperv/hyperv_network_api_v1.h
@@ -1,5 +1,5 @@
 /*
- * hyperv_network_driver.c: network driver functions for managing
+ * hyperv_network_api_v1.h: network driver functions for managing
  *                          Microsoft Hyper-V host networks (API v1)
  *
  * Copyright (C) 2017 Datto Inc.
@@ -23,7 +23,9 @@
 #ifndef __HYPERV_NETWORK_API_V1_H__
 # define __HYPERV_NETWORK_API_V1_H__
 
-
+int hyperv1ConnectListAllNetworks(virConnectPtr conn,
+                                  virNetworkPtr **networks,
+                                  unsigned int flags);
 int hyperv1ConnectListNetworks(virConnectPtr conn, char **const names, int maxnames);
 int hyperv1ConnectNumOfNetworks(virConnectPtr conn);
 int hyperv1ConnectListDefinedNetworks(virConnectPtr conn, char **const names,

--- a/src/hyperv/hyperv_network_api_v2.h
+++ b/src/hyperv/hyperv_network_api_v2.h
@@ -1,5 +1,5 @@
 /*
- * hyperv_network_driver_v2.h: network driver functions for managing
+ * hyperv_network_api_v2.h: network driver functions for managing
  *                          Microsoft Hyper-V host networks (API v2)
  *
  * Copyright (C) 2017 Datto Inc.
@@ -24,6 +24,9 @@
 # define __HYPERV_NETWORK_API_V2_H__
 
 
+int hyperv2ConnectListAllNetworks(virConnectPtr conn,
+                                  virNetworkPtr **networks,
+                                  unsigned int flags);
 int hyperv2ConnectListNetworks(virConnectPtr conn, char **const names, int maxnames);
 int hyperv2ConnectNumOfNetworks(virConnectPtr conn);
 int hyperv2ConnectListDefinedNetworks(virConnectPtr conn, char **const names,

--- a/src/hyperv/hyperv_network_api_v2.h
+++ b/src/hyperv/hyperv_network_api_v2.h
@@ -33,6 +33,10 @@ int hyperv2ConnectListDefinedNetworks(virConnectPtr conn, char **const names,
         int maxnames);
 virNetworkPtr hyperv2NetworkLookupByName(virConnectPtr conn, const char *name);
 int hyperv2ConnectNumOfDefinedNetworks(virConnectPtr conn);
-
+char *hyperv2NetworkGetXMLDesc(virNetworkPtr network, unsigned int flags);
+int hyperv2NetworkSetAutostart(virNetworkPtr network, int autostart);
+int hyperv2NetworkGetAutostart(virNetworkPtr network, int *autostart);
+int hyperv2NetworkIsActive(virNetworkPtr network);
+int hyperv2NetworkIsPersistent(virNetworkPtr network);
 
 #endif /* __HYPERV_NETWORK_API_V2_H__ */

--- a/src/hyperv/hyperv_wmi.c
+++ b/src/hyperv/hyperv_wmi.c
@@ -31,10 +31,13 @@
 #include "viralloc.h"
 #include "viruuid.h"
 #include "virbuffer.h"
+#include "virlog.h"
 #include "hyperv_private.h"
 #include "hyperv_wmi.h"
 #include "virstring.h"
 #include "hyperv_wmi_cimtypes.generated.h"
+
+VIR_LOG_INIT("hyperv.hyperv_wmi")
 
 #define WS_SERIALIZER_FREE_MEM_WORKS 0
 
@@ -42,6 +45,21 @@
 #define VIR_FROM_THIS VIR_FROM_HYPERV
 
 
+void
+hypervDebugResponseXml(WsXmlDocH response)
+{
+#ifdef ENABLE_DEBUG
+    char *buf = NULL;
+    int len;
+
+    ws_xml_dump_memory_enc(response, &buf, &len, "UTF-8");
+
+    if (buf && len > 0)
+        VIR_DEBUG("%s", buf);
+
+    ws_xml_free_memory(buf);
+#endif
+}
 
 int
 hyperyVerifyResponse(WsManClient *client, WsXmlDocH response,

--- a/src/hyperv/hyperv_wmi.h
+++ b/src/hyperv/hyperv_wmi.h
@@ -43,6 +43,8 @@
 
 typedef struct _hypervObject hypervObject;
 
+void hypervDebugResponseXml(WsXmlDocH response);
+
 int hyperyVerifyResponse(WsManClient *client, WsXmlDocH response,
                          const char *detail);
 


### PR DESCRIPTION
* make VM XML network interface always use 
````xml
<interface type="bridge"><source bridge="GUID"/></interface>
````
for both define and dumpxml actions
* implement virConectListAllNetworks, virNetworkGetXMLDesc and other networking methods so that we can get lists of Hyper-V networks by getting network handles and then get network UUIDs (as names may be duplicated)
