### PR TITLE
hyperv: fix virConnectListAllNetworks.

### DIFF
--- a/src/hyperv/hyperv_network_api_v1.c
+++ b/src/hyperv/hyperv_network_api_v1.c
@@ -162,7 +162,7 @@ hyperv1ConnectListAllNetworks(virConnectPtr conn,
 
         nets[i] = network;
         network = NULL;
-        vSwitch = vSwitchList->next;
+        vSwitch = vSwitch->next;
     }
 
     ret = count;

--- a/src/hyperv/hyperv_network_api_v2.c
+++ b/src/hyperv/hyperv_network_api_v2.c
@@ -160,7 +160,7 @@ hyperv2ConnectListAllNetworks(virConnectPtr conn,
 
         nets[i] = network;
         network = NULL;
-        vSwitch = vSwitchList->next;
+        vSwitch = vSwitch->next;
     }
 
     ret = count;


### PR DESCRIPTION
When applying code review feedback, the in-loop vSwitch reference was not updated correctly resulting in incorrect behavior.