### PR TITLE
handle differences in "v1" implementations between Windows 2008 and 2012 (non-R2)

### DIFF
--- a/src/hyperv/hyperv_api_v1.c
+++ b/src/hyperv/hyperv_api_v1.c
@@ -1636,11 +1636,19 @@ hyperv1DomainAttachSyntheticEthernetAdapter(virDomainPtr domain,
     params[3].type = SIMPLE_PARAM;
     params[3].param = &virtualSwitch_ScopeOfResidence;
 
-    if (virAsprintf(&vswitch_selector,
-                      "CreationClassName=Msvm_VirtualSwitchManagementService&"
-                      "Name=nvspwmi&SystemCreationClassName=Msvm_ComputerSystem&"
-                      "SystemName=%s", hostname) < 0)
+    /* even though 2008 R2 and 2012 (non-R2) share the same "v1" API, there
+     * are subtle differences that still need to be handled
+     */
+    if (STRPREFIX(priv->winVersion, HYPERV_VERSION_2008)) {
+        if (virAsprintf(&vswitch_selector,
+                        "CreationClassName=Msvm_VirtualSwitchManagementService&"
+                        "Name=nvspwmi&SystemCreationClassName=Msvm_ComputerSystem&"
+                        "SystemName=%s", hostname) < 0)
+            goto cleanup;
+    } else if (VIR_STRDUP(vswitch_selector,
+                          "CreationClassName=Msvm_VirtualSwitchManagementService") < 0) {
         goto cleanup;
+    }
 
     if (hyperv1InvokeMethod(priv, params, 4, "CreateSwitchPort",
                 MSVM_VIRTUALSWITCHMANAGEMENTSERVICE_V1_RESOURCE_URI,

--- a/src/hyperv/hyperv_network_api_v1.c
+++ b/src/hyperv/hyperv_network_api_v1.c
@@ -237,14 +237,15 @@ hyperv1NetworkLookupByName(virConnectPtr conn, const char *name)
         virtualSwitch == NULL) {
         virReportError(VIR_ERR_NO_NETWORK,
                        _("No network found with name %s"), name);
-        return NULL;
+        goto cleanup;
     }
 
 
     ignore_value(hyperv1MsvmVirtualSwitchToNetwork(conn, virtualSwitch, &network));
 
+ cleanup:
+    VIR_FREE(filter);
     hypervFreeObject(priv, (hypervObject *) virtualSwitch);
-
     return network;
 }
 
@@ -281,7 +282,7 @@ hyperv1NetworkGetXMLDesc(virNetworkPtr network, unsigned int flags)
 
     if (hyperv1GetVirtualSwitchList(priv, filter, &vSwitch) < 0 ||
         vSwitch == NULL)
-        return NULL;
+        goto cleanup;
 
     memcpy(def->uuid, network->uuid, VIR_UUID_BUFLEN);
     def->uuid_specified = true;
@@ -294,6 +295,7 @@ hyperv1NetworkGetXMLDesc(virNetworkPtr network, unsigned int flags)
     xml = virNetworkDefFormat(def, flags);
 
  cleanup:
+    VIR_FREE(filter);
     hypervFreeObject(priv, (hypervObject *) vSwitch);
     virNetworkDefFree(def);
 

--- a/src/hyperv/hyperv_network_api_v2.c
+++ b/src/hyperv/hyperv_network_api_v2.c
@@ -235,11 +235,13 @@ hyperv2NetworkLookupByName(virConnectPtr conn, const char *name)
         virtualSwitch == NULL) {
         virReportError(VIR_ERR_NO_NETWORK,
                        _("No network found with name %s"), name);
-        return NULL;
+        goto cleanup;
     }
 
     ignore_value(hyperv2MsvmVirtualSwitchToNetwork(conn, virtualSwitch, &network));
 
+ cleanup:
+    VIR_FREE(filter);
     hypervFreeObject(priv, (hypervObject *) virtualSwitch);
 
     return network;
@@ -278,7 +280,7 @@ hyperv2NetworkGetXMLDesc(virNetworkPtr network, unsigned int flags)
 
     if (hyperv2GetVirtualSwitchList(priv, filter, &vSwitch) < 0 ||
         vSwitch == NULL)
-        return NULL;
+        goto cleanup;
 
     memcpy(def->uuid, network->uuid, VIR_UUID_BUFLEN);
     def->uuid_specified = true;
@@ -291,6 +293,7 @@ hyperv2NetworkGetXMLDesc(virNetworkPtr network, unsigned int flags)
     xml = virNetworkDefFormat(def, flags);
 
  cleanup:
+    VIR_FREE(filter);
     hypervFreeObject(priv, (hypervObject *) vSwitch);
     virNetworkDefFree(def);
 

--- a/src/hyperv/hyperv_private.h
+++ b/src/hyperv/hyperv_private.h
@@ -37,6 +37,7 @@ struct _hypervPrivate {
     WsManClient *client;
     virCapsPtr caps;
     virDomainXMLOptionPtr xmlopt;
+    char *winVersion;
 };
 
 void hypervFreePrivate(hypervPrivate **priv);


### PR DESCRIPTION
While 2008 R2 and 2012 use the same "v1" API, apparently there are minor differences on how they handle more complex invoke request. This patch adds winVersion field to hypervPrivate structure so we can test for specific Windows versions anywhere in the driver code in order to handle such cases as needed.

Aside from that, plug a memory leak in the hyperv network driver - the filter variable needs to be free'd as it's heap allocated not stack allocated as I wrongfully thought in last pull.